### PR TITLE
Fix broken test on builds relying on poco 1.12.x

### DIFF
--- a/test/mock_server.cpp
+++ b/test/mock_server.cpp
@@ -124,7 +124,8 @@ void MockServer<C>::serverThread() {
                            : typename C::Connect::Response(C::Connect::Status::kSuccess);
       });
 
-  Poco::Net::DatagramSocket udp_socket({kHostname, 0});
+  Poco::Net::DatagramSocket udp_socket;
+  udp_socket.bind({kHostname, 0});
   udp_socket.setBlocking(true);
   Socket udp_socket_wrapper;
   udp_socket_wrapper.sendBytes = [&](const void* data, size_t size) {


### PR DESCRIPTION
I run into build failures on arch when building libfranka via the [ros-noetic-libfranka aur package](https://aur.archlinux.org/packages/ros-noetic-libfranka). I get the following build failure.

```bash
/home/anthony/robotics/libfranka/test/mock_server.cpp:227:16:   required from here
/home/anthony/robotics/libfranka/test/mock_server.cpp:127:29: error: no matching function for call to ‘Poco::Net::DatagramSocket::DatagramSocket(<brace-enclosed initializer list>)’
  127 |   Poco::Net::DatagramSocket udp_socket({kHostname, 0});
      |                             ^~~~~~~~~~
/usr/include/Poco/Net/DatagramSocket.h:283:9: note: candidate: ‘Poco::Net::DatagramSocket::DatagramSocket(Poco::Net::SocketImpl*)’
  283 |         DatagramSocket(SocketImpl* pImpl);
      |         ^~~~~~~~~~~~~~
/usr/include/Poco/Net/DatagramSocket.h:283:36: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘Poco::Net::SocketImpl*’
  283 |         DatagramSocket(SocketImpl* pImpl);
      |                        ~~~~~~~~~~~~^~~~~
/usr/include/Poco/Net/DatagramSocket.h:66:9: note: candidate: ‘Poco::Net::DatagramSocket::DatagramSocket(const Poco::Net::DatagramSocket&)’
   66 |         DatagramSocket(const DatagramSocket& socket);
      |         ^~~~~~~~~~~~~~
/usr/include/Poco/Net/DatagramSocket.h:66:46: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘const Poco::Net::DatagramSocket&’
   66 |         DatagramSocket(const DatagramSocket& socket);
      |                        ~~~~~~~~~~~~~~~~~~~~~~^~~~~~
/usr/include/Poco/Net/DatagramSocket.h:60:9: note: candidate: ‘Poco::Net::DatagramSocket::DatagramSocket(const Poco::Net::Socket&)’
   60 |         DatagramSocket(const Socket& socket);
      |         ^~~~~~~~~~~~~~
/usr/include/Poco/Net/DatagramSocket.h:60:38: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘const Poco::Net::Socket&’
   60 |         DatagramSocket(const Socket& socket);
      |                        ~~~~~~~~~~~~~~^~~~~~
/usr/include/Poco/Net/DatagramSocket.h:51:9: note: candidate: ‘Poco::Net::DatagramSocket::DatagramSocket(const Poco::Net::SocketAddress&, bool, bool, bool)’
   51 |         DatagramSocket(const SocketAddress& address, bool reuseAddress, bool reusePort = false, bool ipV6Only = false);
      |         ^~~~~~~~~~~~~~
/usr/include/Poco/Net/DatagramSocket.h:51:9: note:   candidate expects 4 arguments, 1 provided
/usr/include/Poco/Net/DatagramSocket.h:45:18: note: candidate: ‘Poco::Net::DatagramSocket::DatagramSocket(Poco::Net::SocketAddress::Family)’
   45 |         explicit DatagramSocket(SocketAddress::Family family);
      |                  ^~~~~~~~~~~~~~
/usr/include/Poco/Net/DatagramSocket.h:45:55: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘Poco::Net::SocketAddress::Family’ {aka ‘Poco::Net::AddressFamily::Family’}
   45 |         explicit DatagramSocket(SocketAddress::Family family);
      |                                 ~~~~~~~~~~~~~~~~~~~~~~^~~~~~
/usr/include/Poco/Net/DatagramSocket.h:35:9: note: candidate: ‘Poco::Net::DatagramSocket::DatagramSocket()’
   35 |         DatagramSocket();
      |         ^~~~~~~~~~~~~~
/usr/include/Poco/Net/DatagramSocket.h:35:9: note:   candidate expects 0 arguments, 1 provided
```

This is because poco changed the `DatagramSocket` constructor (presumably in https://github.com/pocoproject/poco/issues/3283, but I can't be sure because of intermittent github issues). The commit that made the breaking change is included in poco 1.12.x: https://github.com/pocoproject/poco/commit/7852153db56737d6cac8a0f82336880b7b31301c

In particular, the following change was made:

```diff
-	DatagramSocket(const SocketAddress& address, bool reuseAddress = false);
- 	DatagramSocket(const SocketAddress& address, bool reuseAddress, bool reusePort);
+	DatagramSocket(const SocketAddress& address, bool reuseAddress, bool reusePort = false, bool ipV6Only = false);
```

This PR resolves the issue by creating an empty socket and binding on it manually, which builds correctly on poco 1.12.1,