### PR TITLE
Fix compilation with Poco >= 1.12

### DIFF
--- a/test/mock_server.cpp
+++ b/test/mock_server.cpp
@@ -116,7 +116,7 @@ void MockServer<C>::serverThread() {
                            : typename C::Connect::Response(C::Connect::Status::kSuccess);
       });
 
-  Poco::Net::DatagramSocket udp_socket({kHostname, 0});
+  Poco::Net::DatagramSocket udp_socket({kHostname, 0}, /*reuseAddress*/ false);
   udp_socket.setBlocking(true);
   Socket udp_socket_wrapper;
   udp_socket_wrapper.sendBytes = [&](const void* data, size_t size) {


### PR DESCRIPTION
Since Poco 1.12, the `DatagramSocket` constructor `DatagramSocket(const SocketAddress& addr, bool reuseAddress=false)` was changed, and there default value of the `reuseAddress` was removed, so to ensure compilation with Poco >= 1.12, it is necessary to explicitly set the `reuseAddress` argument. As before the second argument already existed, the change is backward compatible.

See https://github.com/pothosware/PothosCore/issues/241 for a similar issue.