### PR TITLE
ci: add Ubuntu 26.04 to CI + minor flags

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -128,7 +128,7 @@ RUN git clone --depth 1 --branch 10.0.0 https://github.com/leethomason/tinyxml2.
 RUN git clone --depth 1 --branch 1.0.2 https://github.com/ros/console_bridge.git \
     && cd console_bridge \
     && mkdir build && cd build \
-    && cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+    && cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=/usr/lib -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
     && make -j4 \
     && make install \
     && cd ../.. \

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -137,7 +137,7 @@ RUN git clone --depth 1 --branch 1.0.2 https://github.com/ros/console_bridge.git
 RUN git clone --depth 1 --branch 1.0.5 https://github.com/ros/urdfdom_headers.git \
     && cd urdfdom_headers \
     && mkdir build && cd build \
-    && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+    && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=/usr/lib -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
     && make -j4 && make install \
     && cd ../.. \
     && rm -rf urdfdom_headers
@@ -147,7 +147,7 @@ RUN git clone --depth 1 --branch 4.0.0 https://github.com/ros/urdfdom.git \
     && cd urdfdom \
     && git apply  /tmp/urdfdom.patch \
     && mkdir build && cd build \
-    && cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+    && cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=/usr/lib -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
     && make -j4 && make install \
     && cd ../.. \
     && rm -rf urdfdom

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -26,16 +26,19 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
-# Add LLVM repository for newer clang versions
+# Add LLVM repository for newer clang versions.
+# apt.llvm.org publishes LLVM 18 for Ubuntu <= 24.04 but only LLVM 21+ for
+# Ubuntu 26.04 (resolute); use LLVM 22 (current stable) for that release.
 RUN apt-get update && \
     apt-get install -y wget gnupg lsb-release software-properties-common && \
     wget https://apt.llvm.org/llvm.sh && \
     chmod +x llvm.sh && \
-    ./llvm.sh 18 && \
+    if [ "${UBUNTU_VERSION}" = "26.04" ]; then LLVM_VER=22; else LLVM_VER=18; fi && \
+    ./llvm.sh ${LLVM_VER} && \
     apt-get update && \
-    apt-get install -y clang-format-18 clang-tidy-18 \
-    && ln -s $(which clang-tidy-18) /usr/bin/clang-tidy \
-    && ln -s $(which clang-format-18) /usr/bin/clang-format
+    apt-get install -y clang-format-${LLVM_VER} clang-tidy-${LLVM_VER} && \
+    ln -s $(which clang-tidy-${LLVM_VER}) /usr/bin/clang-tidy && \
+    ln -s $(which clang-format-${LLVM_VER}) /usr/bin/clang-format
 
 # Install necessary packages (without Python - we'll install specific version later)
 # Note: pybind11-dev kept for devcontainer users (works with Ubuntu's default Python)

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -155,7 +155,7 @@ RUN git clone --depth 1 --branch 4.0.0 https://github.com/ros/urdfdom.git \
 RUN git clone --depth 1 --recurse-submodules --shallow-submodules --branch v5.4.3 https://github.com/assimp/assimp.git \
     && cd assimp \
     && mkdir build && cd build \
-    && cmake .. -DBoost_USE_STATIC_LIBS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_SHARED_LIBS=OFF -DASSIMP_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+    && cmake .. -DBoost_USE_STATIC_LIBS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_SHARED_LIBS=OFF -DASSIMP_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=/usr/lib -DASSIMP_WARNINGS_AS_ERRORS=OFF \
     && make -j4 && make install \
     && cd ../.. \
     && rm -rf assimp

--- a/.ci/urdfdom.patch
+++ b/.ci/urdfdom.patch
@@ -5,7 +5,7 @@ index 20a6a05..5577e99 100644
 @@ -3,7 +3,7 @@ macro(add_urdfdom_library)
    set(multiValueArgs SOURCES LINK)
    cmake_parse_arguments(add_urdfdom_library "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-
+ 
 -  add_library(${add_urdfdom_library_LIBNAME} SHARED
 +  add_library(${add_urdfdom_library_LIBNAME} STATIC
      ${add_urdfdom_library_SOURCES})
@@ -14,10 +14,10 @@ index 20a6a05..5577e99 100644
 diff --git a/urdf_parser/include/urdf_parser/urdf_parser.h b/urdf_parser/include/urdf_parser/urdf_parser.h
 --- a/urdf_parser/include/urdf_parser/urdf_parser.h
 +++ b/urdf_parser/include/urdf_parser/urdf_parser.h
-@@ -49,6 +49,7 @@
- #include <string>
- #include <vector>
+@@ -49,5 +49,6 @@
+ #include <urdf_world/types.h>
+ 
  #include "exportdecl.h"
 +#include <cstdint>
-
- namespace urdf_export_helpers {
+ 
+ namespace tinyxml2{

--- a/.ci/urdfdom.patch
+++ b/.ci/urdfdom.patch
@@ -11,3 +11,13 @@ index 20a6a05..5577e99 100644
      ${add_urdfdom_library_SOURCES})
    target_include_directories(${add_urdfdom_library_LIBNAME} PUBLIC
      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+diff --git a/urdf_parser/include/urdf_parser/urdf_parser.h b/urdf_parser/include/urdf_parser/urdf_parser.h
+--- a/urdf_parser/include/urdf_parser/urdf_parser.h
++++ b/urdf_parser/include/urdf_parser/urdf_parser.h
+@@ -49,6 +49,7 @@
+ #include <string>
+ #include <vector>
+ #include "exportdecl.h"
++#include <cstdint>
+
+ namespace urdf_export_helpers {

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -48,6 +48,10 @@ jobs:
             ubuntu-version: '22.04'
             name: 'Python 3.12'
             tag-prefix: 'py'
+          - python-version: '3.14'
+            ubuntu-version: '26.04'  # Ubuntu 26.04 for glibc 2.43 compatibility
+            name: 'Python 3.14'
+            tag-prefix: 'py'
           # Debian package build images (Ubuntu version specific)
           - python-version: '3.8'
             ubuntu-version: '20.04'
@@ -60,6 +64,10 @@ jobs:
           - python-version: '3.12'
             ubuntu-version: '24.04'
             name: 'Ubuntu 24.04'
+            tag-prefix: 'ubuntu'
+          - python-version: '3.14'
+            ubuntu-version: '26.04'
+            name: 'Ubuntu 26.04'
             tag-prefix: 'ubuntu'
 
     steps:

--- a/.github/workflows/libfranka-build.yml
+++ b/.github/workflows/libfranka-build.yml
@@ -31,6 +31,8 @@ jobs:
             python_version: "3.10"
           - ubuntu_version: "24.04"
             python_version: "3.12"
+          - ubuntu_version: "26.04"
+            python_version: "3.14"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/pylibfranka-wheels.yml
+++ b/.github/workflows/pylibfranka-wheels.yml
@@ -39,6 +39,10 @@ jobs:
             python-tag: 'cp312'
             ubuntu-version: '22.04'
             manylinux-tag: 'manylinux_2_34_x86_64'
+          - python-version: '3.14'
+            python-tag: 'cp314'
+            ubuntu-version: '26.04'
+            manylinux-tag: 'manylinux_2_43_x86_64'
 
     steps:
       - name: Checkout code

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Before using **libfranka**, ensure your system meets the following requirements:
 
 .. _installation-debian-package:
 
-1. Installation from Debian Package (Recommended)
+2. Installation from Debian Package (Recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The easiest way to install **libfranka** is by using the pre-built Debian packages

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Key Features
 
 - **Low-level control**: Access precise motion control for research robots.
 - **Real-time communication**: Interact with the robot in real-time.
-- **Multi-platform support**: Ubuntu 20.04, 22.04, and 24.04 LTS
+- **Multi-platform support**: Ubuntu 20.04, 22.04, 24.04, and 26.04 LTS
 
 
 1. System Requirements
@@ -46,6 +46,7 @@ Before using **libfranka**, ensure your system meets the following requirements:
    - Ubuntu 20.04 LTS (Focal Fossa)
    - Ubuntu 22.04 LTS (Jammy Jellyfish)
    - Ubuntu 24.04 LTS (Noble Numbat)
+   - Ubuntu 26.04 LTS (Resolute Raccoon)
    - `Linux with PREEMPT_RT patched kernel <https://frankarobotics.github.io/docs/doc/libfranka/docs/real_time_kernel.html>`_ recommended for real-time control
 
 **Build Tools** (for building from source):
@@ -59,7 +60,7 @@ Before using **libfranka**, ensure your system meets the following requirements:
 
 .. _installation-debian-package:
 
-2. Installation from Debian Package (Recommended)
+1. Installation from Debian Package (Recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The easiest way to install **libfranka** is by using the pre-built Debian packages
@@ -94,6 +95,12 @@ Supported Platforms
      - .. image:: https://img.shields.io/github/actions/workflow/status/frankarobotics/libfranka/libfranka-build.yml?label=Ubuntu+24.04&logo=ubuntu&logoColor=white
           :target: https://github.com/frankarobotics/libfranka/actions/workflows/libfranka-build.yml
           :alt: Ubuntu 24.04 build status
+   * - 26.04 LTS
+     - resolute
+     - amd64
+     - .. image:: https://img.shields.io/github/actions/workflow/status/frankarobotics/libfranka/libfranka-build.yml?label=Ubuntu+26.04&logo=ubuntu&logoColor=white
+          :target: https://github.com/frankarobotics/libfranka/actions/workflows/libfranka-build.yml
+          :alt: Ubuntu 26.04 build status
 
 Quick Install
 ^^^^^^^^^^^^^
@@ -230,6 +237,9 @@ Method B: Using Docker Command Line
 
       # For Ubuntu 24.04
       docker build --build-arg UBUNTU_VERSION=24.04 -t libfranka-build:24.04 .ci/
+
+      # For Ubuntu 26.04
+      docker build --build-arg UBUNTU_VERSION=26.04 -t libfranka-build:26.04 .ci/
 
 2. **Run the container and build**
 
@@ -540,6 +550,10 @@ For more examples, see the `Usage Examples documentation <https://frankarobotics
      - .. image:: https://img.shields.io/github/actions/workflow/status/frankarobotics/libfranka/pylibfranka-wheels.yml?label=python3.12&logo=python&logoColor=white
           :target: https://github.com/frankarobotics/libfranka/actions/workflows/pylibfranka-wheels.yml
           :alt: Python 3.12 wheel build status
+   * - Ubuntu 26.04
+     - .. image:: https://img.shields.io/github/actions/workflow/status/frankarobotics/libfranka/pylibfranka-wheels.yml?label=python3.14&logo=python&logoColor=white
+          :target: https://github.com/frankarobotics/libfranka/actions/workflows/pylibfranka-wheels.yml
+          :alt: Python 3.14 wheel build status
 
 **Pylibfranka** provides Python bindings for libfranka, allowing robot control with Python.
 
@@ -678,6 +692,8 @@ Platform Compatibility
      - Python 3.9, 3.10, 3.11, 3.12
    * - 24.04 (Noble)
      - Python 3.9, 3.10, 3.11, 3.12
+   * - 26.04 (Resolute Raccoon)
+     - Python 3.14
 
 **Note:** Ubuntu 20.04 users must use Python 3.9 due to glibc compatibility requirements.
 


### PR DESCRIPTION
I added ubuntu 26.04 as the latest paltform to

- `docker-image.yml`
- `libfranka-build.yml`
- `pylibfranka-wheels.yml`

I also made minor modifications to the `urdf ` patch, and in the `Dockerfile` to dependencies and command flags