### PR TITLE
Update README with submodule update command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,6 +160,7 @@ Clone the Repository
    git clone --recurse-submodules https://github.com/frankarobotics/libfranka.git
    cd libfranka
    git checkout 0.19.0  # or your desired version
+   git submodule update
 
 Method A: Using Visual Studio Code (Recommended)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The submodules should be updated for older versions of libfranka (eg: 0.9.2). Their newer versions that ship with the repo will not work.
I have made the change to the README instruction