### PR TITLE
Improve pylibfranka missing-dependency diagnostics

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -710,6 +710,7 @@ Prerequisites
 - C++ compiler with C++17 support
 - Eigen3 development headers
 - Poco development headers
+- Full libfranka native CMake dependencies already installed
 
 **Disclaimer: If you are using the provided devcontainer, you can skip the prerequisites installation as they are already included in the container.**
 
@@ -721,14 +722,26 @@ Installing Prerequisites on Ubuntu/Debian
    sudo apt-get update
    sudo apt-get install -y build-essential cmake libeigen3-dev libpoco-dev python3-dev
 
+The apt command above installs only the basic toolchain. Before running pip, install the
+full native dependency set from the source-build instructions, including
+``console_bridge``, ``TinyXML2``, and the patched ``Pinocchio`` build, or point CMake
+to an existing installation with ``*_DIR`` variables or ``CMAKE_PREFIX_PATH``.
+
 Build and Install
 ~~~~~~~~~~~~~~~~~
 
-From the root folder, you can install `pylibfranka` using pip:
+You can install ``pylibfranka`` either from the repository root:
 
 .. code-block:: bash
 
    pip install ./pylibfranka
+
+or from inside the ``pylibfranka/`` subdirectory:
+
+.. code-block:: bash
+
+   cd pylibfranka
+   pip install .
 
 
 This will install pylibfranka in your current Python environment.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -152,6 +152,7 @@ Prerequisites
 - C++ compiler with C++17 support
 - Eigen3 development headers
 - Poco development headers
+- Full libfranka native CMake dependencies already installed
 
 .. tip::
 
@@ -165,14 +166,30 @@ Installing Prerequisites on Ubuntu/Debian
    sudo apt-get update
    sudo apt-get install -y build-essential cmake libeigen3-dev libpoco-dev python3-dev
 
+.. important::
+
+   ``pip install ./pylibfranka`` (from the repo root) and ``cd pylibfranka && pip install .``
+   (from the subdirectory) only build the Python bindings. They do not install
+   native CMake dependencies. Install the full libfranka source-build dependency set
+   first, including ``console_bridge``, ``TinyXML2``, and the patched ``Pinocchio``
+   build described in the source-build instructions, or set ``*_DIR`` /
+   ``CMAKE_PREFIX_PATH`` to existing dependency installations.
+
 Build and Install
 ^^^^^^^^^^^^^^^^^
 
-From the libfranka root folder, install pylibfranka using pip:
+Install pylibfranka using either of these equivalent commands:
 
 .. code-block:: bash
 
    pip install ./pylibfranka
+
+or:
+
+.. code-block:: bash
+
+   cd pylibfranka
+   pip install .
 
 This will build the C++ extension and install pylibfranka in your current Python environment.
 

--- a/pylibfranka/README.md
+++ b/pylibfranka/README.md
@@ -44,6 +44,7 @@ If you need to build from source (e.g., for development or unsupported platforms
 - C++ compiler with C++17 support
 - Eigen3 development headers
 - Poco development headers
+- Full libfranka native CMake dependencies already installed
 
 **Disclaimer: If you are using the provided devcontainer, you can skip the prerequisites installation as they are already included in the container.**
 
@@ -54,11 +55,23 @@ sudo apt-get update
 sudo apt-get install -y build-essential cmake libeigen3-dev libpoco-dev python3-dev
 ```
 
+The apt command above installs only the basic toolchain. Before running pip, install the
+full native dependency set from the libfranka root source-build instructions, including
+`console_bridge`, `TinyXML2`, and the patched `Pinocchio` build, or point CMake to an
+existing installation with `*_DIR` variables or `CMAKE_PREFIX_PATH`.
+
 #### Build and Install
 
-From the `pylibfranka/` folder, you can install `pylibfranka` using pip:
+You can install `pylibfranka` either from the libfranka repository root:
 
 ```bash
+pip install ./pylibfranka
+```
+
+or from inside the `pylibfranka/` subdirectory:
+
+```bash
+cd pylibfranka
 pip install .
 ```
 

--- a/pylibfranka/setup.py
+++ b/pylibfranka/setup.py
@@ -1,3 +1,4 @@
+import importlib.util
 import os
 import re
 import subprocess
@@ -13,6 +14,20 @@ ROOT_DIR = Path(__file__).parent
 # subproject; the shared version lives in the top-level CMakeLists.txt and the
 # native build is driven from the repo root (add_subdirectory(pylibfranka)).
 REPO_ROOT = ROOT_DIR.parent
+
+
+def load_setup_helpers():
+    helper_path = ROOT_DIR / "setup_helpers.py"
+    spec = importlib.util.spec_from_file_location("pylibfranka_setup_helpers", helper_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load setup helpers from {helper_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+SETUP_HELPERS = load_setup_helpers()
 
 
 def get_version():
@@ -103,7 +118,21 @@ class CMakeBuild(build_ext):
         if pybind11_dir:
             cmake_args.append(f"-Dpybind11_DIR={pybind11_dir}")
 
-        subprocess.check_call(["cmake", ext.sourcedir] + cmake_args, cwd=build_temp)
+        configure = subprocess.run(
+            ["cmake", ext.sourcedir] + cmake_args,
+            cwd=build_temp,
+            capture_output=True,
+            text=True,
+        )
+        if configure.returncode != 0:
+            sys.stdout.write(configure.stdout)
+            sys.stderr.write(configure.stderr)
+            guidance = SETUP_HELPERS.explain_cmake_configure_failure(
+                configure.stdout, configure.stderr
+            )
+            if guidance:
+                raise RuntimeError(guidance)
+            configure.check_returncode()
         subprocess.check_call(
             ["cmake", "--build", ".", "--config", "Release", "--parallel"],
             cwd=build_temp,

--- a/pylibfranka/setup_helpers.py
+++ b/pylibfranka/setup_helpers.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import re
+
+
+def explain_cmake_configure_failure(stdout: str, stderr: str) -> str | None:
+    """Return an actionable packaging error for known CMake dependency failures."""
+    output = "\n".join(part for part in (stdout, stderr) if part)
+
+    match = re.search(
+        r'Could not find a package configuration file provided by\s+"([^"]+)"',
+        output,
+        re.DOTALL,
+    )
+    if not match:
+        match = re.search(
+            r'By not providing "Find([A-Za-z0-9_+-]+)\.cmake" in CMAKE_MODULE_PATH'
+            r".*?asked CMake to find a package configuration file",
+            output,
+            re.DOTALL,
+        )
+    if match:
+        package_name = match.group(1)
+        return (
+            "Could not configure pylibfranka because CMake could not find the required native "
+            f"dependency '{package_name}'. Before running 'pip install ./pylibfranka', install "
+            "the full libfranka source-build dependency set (including console_bridge, "
+            "TinyXML2, and Pinocchio) or point CMake to an existing installation with "
+            f"{package_name}_DIR or CMAKE_PREFIX_PATH. The Python wheel build cannot install "
+            "native CMake dependencies for you."
+        )
+
+    return None

--- a/pylibfranka/tests/test_setup_helpers.py
+++ b/pylibfranka/tests/test_setup_helpers.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from setup_helpers import explain_cmake_configure_failure
+
+
+def test_explain_cmake_configure_failure_for_missing_pinocchio():
+    message = explain_cmake_configure_failure(
+        "",
+        """
+        CMake Error at CMakeLists.txt:54 (find_package):
+          By not providing "Findpinocchio.cmake" in CMAKE_MODULE_PATH this project
+          has asked CMake to find a package configuration file provided by
+          "pinocchio", but CMake did not find one.
+        """,
+    )
+
+    assert message is not None
+    assert "pinocchio" in message
+    assert "pip install ./pylibfranka" in message
+    assert "pinocchio_DIR" in message
+    assert "CMAKE_PREFIX_PATH" in message
+    assert "console_bridge" in message
+
+
+def test_explain_cmake_configure_failure_for_missing_console_bridge():
+    message = explain_cmake_configure_failure(
+        "",
+        """
+        CMake Error at CMakeLists.txt:51 (find_package):
+          Could not find a package configuration file provided by "console_bridge"
+          with any of the following names:
+
+            console_bridgeConfig.cmake
+            console_bridge-config.cmake
+        """,
+    )
+
+    assert message is not None
+    assert "console_bridge" in message
+    assert "console_bridge_DIR" in message
+
+
+def test_explain_cmake_configure_failure_ignores_other_errors():
+    assert explain_cmake_configure_failure("", "CMake Error: unrelated failure") is None
+
+
+def test_explain_cmake_configure_failure_ignores_incidental_find_cmake_mentions():
+    assert (
+        explain_cmake_configure_failure(
+            "",
+            'See docs for Findpinocchio.cmake lookup order, but this is not a missing package error.',
+        )
+        is None
+    )


### PR DESCRIPTION
## Summary

- turn recognized CMake missing-package failures into actionable pylibfranka source-build errors
- preserve raw failure behavior for unrelated CMake errors
- document the full native dependency prerequisite and both supported install invocation forms
- add positive and negative parser regression tests

## Context

This improves the source-install failure experience discussed in #242. It does not remove libfranka's native dependency requirements and does not claim to close that broader issue.

## Verification

- `python -m pytest pylibfranka/tests/test_setup_helpers.py -q` (4 passed)
- `python -m compileall` on modified Python files
- Docker repro from repo root: `pip install ./pylibfranka` reaches targeted `console_bridge` guidance
- Docker repro from `pylibfranka/`: `pip install .` reaches the same targeted guidance
- unrelated and incidental `Find*.cmake` messages remain unclassified

A successful wheel build with the complete native dependency stack was not performed.